### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ git clone https://github.com/danmartuszewski/hop.git && cd hop && make build
 ./bin/hop
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/danmartuszewski-hop).
+
 ## Features
 
 - **Fuzzy matching** - Type `hop prod` to connect to `app-server-prod-03`


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/danmartuszewski-hop).