### PR TITLE
feat(tui): Add configurable theme and custom color palette support

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,5 +1,33 @@
 version: 1
 
+# Optional theme overrides. `theme:` is the shared base palette applied
+# to both dark and light terminals. `theme_dark:` and `theme_light:`
+# layer on top of it for their respective backgrounds and only need to
+# list the colors that differ. Any color not set at any layer keeps the
+# built-in default.
+#
+# Color values accept either an ANSI 256 code as a quoted number (e.g. "39")
+# or a hex string (e.g. "#bd93f9"). ANSI codes adapt to your terminal's
+# palette; hex values are absolute.
+#
+# All available keys (default values shown):
+# theme:
+#   primary: "39"      # headers, titles, selected items, help keys
+#   secondary: "245"   # borders, version, host, footer text
+#   accent: "212"      # project labels, tag highlights
+#   success: "82"      # user, healthy hosts
+#   warning: "214"     # environment labels
+#   error: "196"       # unreachable hosts
+#   muted: "240"       # port numbers, low-emphasis text
+#   selection: "236"   # tag pill background
+#   foreground: "255"  # filter input text
+#
+# Override only what you need; for example:
+# theme_dark:
+#   primary: "39"
+# theme_light:
+#   primary: "#0066cc"
+
 defaults:
   user: deploy
   port: 22

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,9 @@ import (
 
 type Config struct {
 	Version     int                 `yaml:"version"`
+	Theme       map[string]string   `yaml:"theme,omitempty"`
+	ThemeDark   map[string]string   `yaml:"theme_dark,omitempty"`
+	ThemeLight  map[string]string   `yaml:"theme_light,omitempty"`
 	Defaults    Defaults            `yaml:"defaults,omitempty"`
 	Connections []Connection        `yaml:"connections"`
 	Groups      map[string][]string `yaml:"groups,omitempty"`

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -99,6 +99,8 @@ func NewModel(cfg *config.Config, version string) Model {
 		history = &config.History{}
 	}
 
+	InitTheme(cfg)
+
 	healthEnabled := cfg.Defaults.HealthCheckEnabled()
 	healthStatus := make(map[string]health.Status)
 	if healthEnabled {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,101 +3,142 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	// Colors
-	primaryColor   = lipgloss.Color("39")  // Cyan
-	secondaryColor = lipgloss.Color("245") // Gray
-	accentColor    = lipgloss.Color("212") // Pink
-	successColor   = lipgloss.Color("82")  // Green
-	warningColor   = lipgloss.Color("214") // Orange
-
 	// Header
-	headerStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(primaryColor).
-			BorderStyle(lipgloss.NormalBorder()).
-			BorderBottom(true).
-			BorderForeground(secondaryColor).
-			Padding(0, 1)
+	headerStyle lipgloss.Style
 
-	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(primaryColor)
+	titleStyle lipgloss.Style
 
-	versionStyle = lipgloss.NewStyle().
-			Foreground(secondaryColor)
+	versionStyle lipgloss.Style
 
 	// Filter
-	filterPromptStyle = lipgloss.NewStyle().
-				Foreground(primaryColor).
-				Bold(true)
+	filterPromptStyle lipgloss.Style
 
-	filterInputStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("255"))
+	filterInputStyle lipgloss.Style
 
 	// List items
-	itemStyle = lipgloss.NewStyle().
-			PaddingLeft(2)
+	itemStyle lipgloss.Style
 
-	selectedItemStyle = lipgloss.NewStyle().
-				PaddingLeft(1).
-				Foreground(primaryColor).
-				Bold(true)
+	selectedItemStyle lipgloss.Style
 
-	projectStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(accentColor)
+	projectStyle lipgloss.Style
 
-	envStyle = lipgloss.NewStyle().
-			Foreground(warningColor)
+	envStyle lipgloss.Style
 
-	hostStyle = lipgloss.NewStyle().
-			Foreground(secondaryColor)
+	hostStyle lipgloss.Style
 
-	userStyle = lipgloss.NewStyle().
-			Foreground(successColor)
+	userStyle lipgloss.Style
 
-	portStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240"))
+	portStyle lipgloss.Style
 
 	// Footer
-	footerStyle = lipgloss.NewStyle().
-			BorderStyle(lipgloss.NormalBorder()).
-			BorderTop(true).
-			BorderForeground(secondaryColor).
-			Foreground(secondaryColor).
-			Padding(0, 1)
+	footerStyle lipgloss.Style
 
-	helpKeyStyle = lipgloss.NewStyle().
-			Foreground(primaryColor).
-			Bold(true)
+	helpKeyStyle lipgloss.Style
 
-	helpDescStyle = lipgloss.NewStyle().
-			Foreground(secondaryColor)
+	helpDescStyle lipgloss.Style
 
 	// Status
-	statusStyle = lipgloss.NewStyle().
-			Foreground(secondaryColor).
-			Italic(true)
+	statusStyle lipgloss.Style
 
 	// Empty state
-	emptyStyle = lipgloss.NewStyle().
-			Foreground(secondaryColor).
-			Italic(true).
-			Padding(2, 4)
+	emptyStyle lipgloss.Style
 
 	// Tag style (used in filter bar and tag picker)
-	panelTagStyle = lipgloss.NewStyle().
-			Foreground(accentColor).
-			Background(lipgloss.Color("236")).
-			Padding(0, 1)
+	panelTagStyle lipgloss.Style
 
 	// Health check indicators
+	healthReachableStyle lipgloss.Style
+
+	healthUnreachableStyle lipgloss.Style
+
+	healthCheckingStyle lipgloss.Style
+)
+
+func init() {
+	refreshStyles()
+}
+
+func refreshStyles() {
+	headerStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(currentTheme.Primary).
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderBottom(true).
+		BorderForeground(currentTheme.Secondary).
+		Padding(0, 1)
+
+	titleStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(currentTheme.Primary)
+
+	versionStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Secondary)
+
+	filterPromptStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Primary).
+		Bold(true)
+
+	filterInputStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Foreground)
+
+	itemStyle = lipgloss.NewStyle().
+		PaddingLeft(2)
+
+	selectedItemStyle = lipgloss.NewStyle().
+		PaddingLeft(1).
+		Foreground(currentTheme.Primary).
+		Bold(true)
+
+	projectStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(currentTheme.Accent)
+
+	envStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Warning)
+
+	hostStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Secondary)
+
+	userStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Success)
+
+	portStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Muted)
+
+	footerStyle = lipgloss.NewStyle().
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderTop(true).
+		BorderForeground(currentTheme.Secondary).
+		Foreground(currentTheme.Secondary).
+		Padding(0, 1)
+
+	helpKeyStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Primary).
+		Bold(true)
+
+	helpDescStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Secondary)
+
+	statusStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Secondary).
+		Italic(true)
+
+	emptyStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Secondary).
+		Italic(true).
+		Padding(2, 4)
+
+	panelTagStyle = lipgloss.NewStyle().
+		Foreground(currentTheme.Accent).
+		Background(currentTheme.Selection).
+		Padding(0, 1)
+
 	healthReachableStyle = lipgloss.NewStyle().
-				Foreground(successColor)
+		Foreground(currentTheme.Success)
 
 	healthUnreachableStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196"))
+		Foreground(currentTheme.Error)
 
 	healthCheckingStyle = lipgloss.NewStyle().
-				Foreground(secondaryColor)
-)
+		Foreground(currentTheme.Secondary)
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,90 @@
+package tui
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/danmartuszewski/hop/internal/config"
+)
+
+// Theme holds the colors used by the TUI styles. Field names map to the
+// keys accepted under theme / theme_dark / theme_light in config.yaml.
+type Theme struct {
+	Primary    lipgloss.Color
+	Secondary  lipgloss.Color
+	Accent     lipgloss.Color
+	Success    lipgloss.Color
+	Warning    lipgloss.Color
+	Error      lipgloss.Color
+	Muted      lipgloss.Color
+	Selection  lipgloss.Color
+	Foreground lipgloss.Color
+}
+
+// defaultTheme preserves the original palette from styles.go.
+// It is used whenever no matching theme override is configured.
+var defaultTheme = Theme{
+	Primary:    lipgloss.Color("39"),  // Cyan
+	Secondary:  lipgloss.Color("245"), // Gray
+	Accent:     lipgloss.Color("212"), // Pink
+	Success:    lipgloss.Color("82"),  // Green
+	Warning:    lipgloss.Color("214"), // Orange
+	Error:      lipgloss.Color("196"), // Red
+	Muted:      lipgloss.Color("240"), // Dark gray
+	Selection:  lipgloss.Color("236"), // Near-black gray
+	Foreground: lipgloss.Color("255"), // Near-white
+}
+
+var currentTheme = defaultTheme
+
+// InitTheme picks a palette based on the terminal background and the
+// theme / theme_dark / theme_light maps in the config. theme is the
+// shared base; theme_dark and theme_light layer on top of it for their
+// respective backgrounds. Each layer only overrides the keys it
+// defines; missing keys fall through to the layer below, ending at the
+// built-in default palette.
+func InitTheme(cfg *config.Config) {
+	shared, dark, light := cfg.Theme, cfg.ThemeDark, cfg.ThemeLight
+
+	t := defaultTheme
+	if lipgloss.HasDarkBackground() {
+		t = applyOverrides(t, shared)
+		t = applyOverrides(t, dark)
+	} else {
+		t = applyOverrides(t, shared)
+		t = applyOverrides(t, light)
+	}
+
+	currentTheme = t
+	refreshStyles()
+}
+
+// applyOverrides patches the given Theme with any non-empty values from
+// the provided color map. Unknown keys and empty values are ignored.
+func applyOverrides(t Theme, m map[string]string) Theme {
+	for key, val := range m {
+		if val == "" {
+			continue
+		}
+		c := lipgloss.Color(val)
+		switch key {
+		case "primary":
+			t.Primary = c
+		case "secondary":
+			t.Secondary = c
+		case "accent":
+			t.Accent = c
+		case "success":
+			t.Success = c
+		case "warning":
+			t.Warning = c
+		case "error":
+			t.Error = c
+		case "muted":
+			t.Muted = c
+		case "selection":
+			t.Selection = c
+		case "foreground":
+			t.Foreground = c
+		}
+	}
+	return t
+}

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/danmartuszewski/hop/internal/config"
+)
+
+func resetTheme(t *testing.T) {
+	t.Helper()
+	prev := currentTheme
+	t.Cleanup(func() {
+		currentTheme = prev
+		refreshStyles()
+	})
+}
+
+func TestInitTheme_NoConfig_KeepsDefaults(t *testing.T) {
+	resetTheme(t)
+	lipgloss.SetHasDarkBackground(true)
+
+	InitTheme(&config.Config{})
+
+	if currentTheme != defaultTheme {
+		t.Fatalf("expected defaults, got %+v", currentTheme)
+	}
+}
+
+func TestInitTheme_SharedThemeAppliesToBothModes(t *testing.T) {
+	resetTheme(t)
+	cfg := &config.Config{
+		Theme: map[string]string{"primary": "99"},
+	}
+
+	lipgloss.SetHasDarkBackground(true)
+	InitTheme(cfg)
+	if got := currentTheme.Primary; got != lipgloss.Color("99") {
+		t.Errorf("dark: primary = %q, want %q", got, "99")
+	}
+
+	lipgloss.SetHasDarkBackground(false)
+	InitTheme(cfg)
+	if got := currentTheme.Primary; got != lipgloss.Color("99") {
+		t.Errorf("light: primary = %q, want %q", got, "99")
+	}
+}
+
+func TestInitTheme_DarkOverridesShared(t *testing.T) {
+	resetTheme(t)
+	lipgloss.SetHasDarkBackground(true)
+
+	cfg := &config.Config{
+		Theme:     map[string]string{"primary": "99", "error": "9"},
+		ThemeDark: map[string]string{"primary": "200"},
+	}
+	InitTheme(cfg)
+
+	if got := currentTheme.Primary; got != lipgloss.Color("200") {
+		t.Errorf("primary = %q, want %q (theme_dark wins)", got, "200")
+	}
+	if got := currentTheme.Error; got != lipgloss.Color("9") {
+		t.Errorf("error = %q, want %q (inherited from theme)", got, "9")
+	}
+	if got := currentTheme.Secondary; got != defaultTheme.Secondary {
+		t.Errorf("secondary = %q, want default %q", got, defaultTheme.Secondary)
+	}
+}
+
+func TestInitTheme_LightOverridesShared(t *testing.T) {
+	resetTheme(t)
+	lipgloss.SetHasDarkBackground(false)
+
+	cfg := &config.Config{
+		Theme:      map[string]string{"primary": "99", "error": "9"},
+		ThemeLight: map[string]string{"primary": "21"},
+	}
+	InitTheme(cfg)
+
+	if got := currentTheme.Primary; got != lipgloss.Color("21") {
+		t.Errorf("primary = %q, want %q (theme_light wins)", got, "21")
+	}
+	if got := currentTheme.Error; got != lipgloss.Color("9") {
+		t.Errorf("error = %q, want %q (inherited from theme)", got, "9")
+	}
+}
+
+func TestInitTheme_EmptyMapDoesNotBreakFallback(t *testing.T) {
+	resetTheme(t)
+	lipgloss.SetHasDarkBackground(true)
+
+	cfg := &config.Config{
+		Theme:     map[string]string{"primary": "99"},
+		ThemeDark: map[string]string{},
+	}
+	InitTheme(cfg)
+
+	if got := currentTheme.Primary; got != lipgloss.Color("99") {
+		t.Errorf("primary = %q, want %q (empty theme_dark must not block theme)", got, "99")
+	}
+}
+
+func TestInitTheme_OppositeModeIsIgnored(t *testing.T) {
+	resetTheme(t)
+	lipgloss.SetHasDarkBackground(true)
+
+	cfg := &config.Config{
+		ThemeLight: map[string]string{"primary": "21"},
+	}
+	InitTheme(cfg)
+
+	if got := currentTheme.Primary; got != defaultTheme.Primary {
+		t.Errorf("primary = %q, want default %q (theme_light must not apply on dark)", got, defaultTheme.Primary)
+	}
+}
+
+func TestApplyOverrides_AllKeys(t *testing.T) {
+	m := map[string]string{
+		"primary":    "1",
+		"secondary":  "2",
+		"accent":     "3",
+		"success":    "4",
+		"warning":    "5",
+		"error":      "6",
+		"muted":      "7",
+		"selection":  "8",
+		"foreground": "9",
+	}
+	got := applyOverrides(defaultTheme, m)
+	want := Theme{
+		Primary:    lipgloss.Color("1"),
+		Secondary:  lipgloss.Color("2"),
+		Accent:     lipgloss.Color("3"),
+		Success:    lipgloss.Color("4"),
+		Warning:    lipgloss.Color("5"),
+		Error:      lipgloss.Color("6"),
+		Muted:      lipgloss.Color("7"),
+		Selection:  lipgloss.Color("8"),
+		Foreground: lipgloss.Color("9"),
+	}
+	if got != want {
+		t.Errorf("applyOverrides:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestApplyOverrides_UnknownAndEmptyKeysIgnored(t *testing.T) {
+	m := map[string]string{
+		"primary": "",
+		"unknown": "999",
+	}
+	got := applyOverrides(defaultTheme, m)
+	if got != defaultTheme {
+		t.Errorf("expected unchanged defaults, got %+v", got)
+	}
+}


### PR DESCRIPTION
### Add configurable theme and custom color palette support

**Default theme preserved**

Light
<img width="723" height="382" alt="default_light" src="https://github.com/user-attachments/assets/0ea06259-2401-486f-9a76-2d788e3f656a" />

Dark
<img width="723" height="382" alt="default_dark" src="https://github.com/user-attachments/assets/9af8c7bf-5ad0-4ea0-b625-4fdc43ca8a2f" />

**Custom Theme Example**

Light
<img width="723" height="382" alt="everforest_light" src="https://github.com/user-attachments/assets/46e401db-7179-462a-8a12-9df15a06ad50" />

Dark
<img width="723" height="382" alt="everforest_dark" src="https://github.com/user-attachments/assets/61098e8a-f253-4677-b1aa-bb35374938a1" />

Config based on the [Everest Theme](https://everforest.vercel.app/palette):
```
theme_dark:
  primary:    "#7FBBB3"  # blue
  secondary:  "#859289"  # grey 1
  accent:     "#D699B6"  # purple
  success:    "#A7C080"  # green
  warning:    "#E69875"  # orange
  error:      "#E67E80"  # red
  muted:      "#7A8478"  # grey 0
  selection:  "#3D484D"  # bg2
  foreground: "#D3C6AA"  # fg
theme_light:
  primary:    "#3A94C5"  # blue
  secondary:  "#939F91"  # grey 1
  accent:     "#DF69BA"  # purple
  success:    "#8DA101"  # green
  warning:    "#F57D26"  # orange
  error:      "#F85552"  # red
  muted:      "#A6B0A0"  # grey 0
  selection:  "#EFEBD4"  # bg2
  foreground: "#5C6A72"  # fg
```

In my case, the light theme is now much more readable.

Thank you for the great product.