### PR TITLE
feat: add identity file field to connection form

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ connections:
   - id: prod-web
     host: web.example.com
     user: deploy
+    identity_file: ~/.ssh/work_key   # Private key for this connection
     project: myapp
     env: production
     tags: [web, prod]

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -17,6 +17,7 @@ const (
 	fieldHost
 	fieldUser
 	fieldPort
+	fieldIdentity
 	fieldProject
 	fieldEnv
 	fieldTags
@@ -29,6 +30,7 @@ type FormModel struct {
 	title      string
 	editing    bool
 	originalID string
+	original   config.Connection
 	width      int
 	height     int
 	cancelled  bool
@@ -51,6 +53,8 @@ func NewFormModel(title string, conn *config.Connection) FormModel {
 			// optional
 		case fieldPort:
 			// Port will be pre-filled with 22
+		case fieldIdentity:
+			// optional - path to a private key
 		case fieldProject:
 			// optional
 		case fieldEnv:
@@ -73,12 +77,14 @@ func NewFormModel(title string, conn *config.Connection) FormModel {
 	if conn != nil {
 		m.editing = true
 		m.originalID = conn.ID
+		m.original = *conn
 		m.inputs[fieldID].SetValue(conn.ID)
 		m.inputs[fieldHost].SetValue(conn.Host)
 		m.inputs[fieldUser].SetValue(conn.User)
 		if conn.Port != 0 {
 			m.inputs[fieldPort].SetValue(strconv.Itoa(conn.Port))
 		}
+		m.inputs[fieldIdentity].SetValue(conn.IdentityFile)
 		m.inputs[fieldProject].SetValue(conn.Project)
 		m.inputs[fieldEnv].SetValue(conn.Env)
 		if len(conn.Tags) > 0 {
@@ -152,7 +158,7 @@ func (m FormModel) View() string {
 	b.WriteString("\n\n")
 
 	// Form fields
-	labels := []string{"ID:", "Host:", "User:", "Port:", "Project:", "Env:", "Tags:"}
+	labels := []string{"ID:", "Host:", "User:", "Port:", "Identity:", "Project:", "Env:", "Tags:"}
 
 	for i, label := range labels {
 		style := helpDescStyle
@@ -163,8 +169,12 @@ func (m FormModel) View() string {
 		b.WriteString(style.Render(fmt.Sprintf("%-10s", label)))
 		b.WriteString(m.inputs[i].View())
 
-		// Add hint for Tags field
-		if formField(i) == fieldTags {
+		// Add hints for fields that benefit from clarification
+		switch formField(i) {
+		case fieldIdentity:
+			b.WriteString(" ")
+			b.WriteString(helpDescStyle.Render("(path to private key)"))
+		case fieldTags:
 			b.WriteString(" ")
 			b.WriteString(helpDescStyle.Render("(comma-separated)"))
 		}
@@ -214,15 +224,19 @@ func (m FormModel) GetConnection() (*config.Connection, error) {
 		}
 	}
 
-	return &config.Connection{
-		ID:      id,
-		Host:    host,
-		User:    strings.TrimSpace(m.inputs[fieldUser].Value()),
-		Port:    port,
-		Project: strings.TrimSpace(m.inputs[fieldProject].Value()),
-		Env:     strings.TrimSpace(m.inputs[fieldEnv].Value()),
-		Tags:    tags,
-	}, nil
+	// Start from the original connection so fields not exposed in the form
+	// (proxy jump, agent forwarding, mosh, extra options) are preserved when
+	// editing or duplicating. For a brand-new connection this is the zero value.
+	conn := m.original
+	conn.ID = id
+	conn.Host = host
+	conn.User = strings.TrimSpace(m.inputs[fieldUser].Value())
+	conn.Port = port
+	conn.IdentityFile = strings.TrimSpace(m.inputs[fieldIdentity].Value())
+	conn.Project = strings.TrimSpace(m.inputs[fieldProject].Value())
+	conn.Env = strings.TrimSpace(m.inputs[fieldEnv].Value())
+	conn.Tags = tags
+	return &conn, nil
 }
 
 func (m FormModel) Cancelled() bool {

--- a/internal/tui/form_test.go
+++ b/internal/tui/form_test.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/danmartuszewski/hop/internal/config"
+)
+
+func TestFormIdentityFilePrefilled(t *testing.T) {
+	conn := &config.Connection{
+		ID:           "prod",
+		Host:         "prod.example.com",
+		User:         "admin",
+		Port:         2222,
+		IdentityFile: "~/.ssh/work_key",
+	}
+
+	m := NewFormModel("Edit Connection", conn)
+
+	if got := m.inputs[fieldIdentity].Value(); got != "~/.ssh/work_key" {
+		t.Errorf("expected identity field pre-filled with %q, got %q", "~/.ssh/work_key", got)
+	}
+}
+
+func TestFormGetConnectionIncludesIdentityFile(t *testing.T) {
+	m := NewFormModel("Add Connection", nil)
+	m.inputs[fieldID].SetValue("box")
+	m.inputs[fieldHost].SetValue("box.example.com")
+	m.inputs[fieldIdentity].SetValue("~/.ssh/id_ed25519")
+
+	conn, err := m.GetConnection()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conn.IdentityFile != "~/.ssh/id_ed25519" {
+		t.Errorf("expected IdentityFile %q, got %q", "~/.ssh/id_ed25519", conn.IdentityFile)
+	}
+}
+
+func TestFormGetConnectionTrimsIdentityFile(t *testing.T) {
+	m := NewFormModel("Add Connection", nil)
+	m.inputs[fieldID].SetValue("box")
+	m.inputs[fieldHost].SetValue("box.example.com")
+	m.inputs[fieldIdentity].SetValue("  ~/.ssh/id_ed25519  ")
+
+	conn, err := m.GetConnection()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if conn.IdentityFile != "~/.ssh/id_ed25519" {
+		t.Errorf("expected trimmed IdentityFile, got %q", conn.IdentityFile)
+	}
+}
+
+// Editing a connection through the form must not drop fields that the form
+// does not expose (proxy jump, agent forwarding, mosh, extra options).
+func TestFormPreservesUnexposedFieldsOnEdit(t *testing.T) {
+	mosh := true
+	conn := &config.Connection{
+		ID:           "gateway",
+		Host:         "gw.example.com",
+		User:         "ops",
+		Port:         22,
+		IdentityFile: "~/.ssh/gw_key",
+		ProxyJump:    "bastion",
+		ForwardAgent: true,
+		UseMosh:      &mosh,
+		Options:      map[string]string{"ServerAliveInterval": "60"},
+	}
+
+	m := NewFormModel("Edit Connection", conn)
+
+	// Change only the user; everything else stays as pre-filled.
+	m.inputs[fieldUser].SetValue("admin")
+
+	updated, err := m.GetConnection()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if updated.User != "admin" {
+		t.Errorf("expected user to be updated to admin, got %q", updated.User)
+	}
+	if updated.ProxyJump != "bastion" {
+		t.Errorf("expected ProxyJump preserved, got %q", updated.ProxyJump)
+	}
+	if !updated.ForwardAgent {
+		t.Error("expected ForwardAgent preserved")
+	}
+	if updated.UseMosh == nil || !*updated.UseMosh {
+		t.Error("expected UseMosh preserved")
+	}
+	if updated.Options["ServerAliveInterval"] != "60" {
+		t.Errorf("expected Options preserved, got %v", updated.Options)
+	}
+	if updated.IdentityFile != "~/.ssh/gw_key" {
+		t.Errorf("expected IdentityFile preserved, got %q", updated.IdentityFile)
+	}
+}


### PR DESCRIPTION
Closes #23.

## What

Adds an **Identity** field to the TUI connection form (Add / Edit / Duplicate / Paste), so an SSH private key path can be set without hand-editing `~/.config/hop/config.yaml`.

```
ID:       > prod
Host:     > prod.example.com
User:     > admin
Port:     > 2222
Identity: > ~/.ssh/work_key  (path to private key)
Project:  >
Env:      >
Tags:     >
```

The `identity_file` field already existed in the config model and was honored by `hop connect`/`hop open` (`ssh -i`); it just wasn't reachable from the dashboard.

## Bug fix

`GetConnection()` rebuilt the connection from only the rendered form fields, so **editing silently dropped** `identity_file`, `proxy_jump`, `forward_agent`, `use_mosh`, and `options`. The form now retains the original connection and overrides only the form-managed fields, preserving the rest on edit/duplicate.

## Changes

- `internal/tui/form.go` — new `fieldIdentity` input, pre-fill on edit, include in `GetConnection()`, preserve unexposed fields
- `internal/tui/form_test.go` — tests for pre-fill, trimming, inclusion, and field preservation
- `README.md` — document `identity_file` in the config example

## Testing

`gofmt`, `go vet`, `go build ./...`, and `go test ./...` all pass.